### PR TITLE
fix exception in has_vertex_pnts_attr()

### DIFF
--- a/check_core/check_functions.py
+++ b/check_core/check_functions.py
@@ -281,9 +281,9 @@ def has_vertex_pnts_attr(mesh_name, fix):
     dag_path.extendToShape()
     dag_node = om.MFnDagNode(dag_path)
     pnts_array = dag_node.findPlug("pnts", True)
-    data_handle = pnts_array.asMdata_handle()
+    data_handle = pnts_array.asMDataHandle()
 
-    arraydata_handle = om.MArraydata_handle(data_handle)
+    arraydata_handle = om.MArrayDataHandle(data_handle)
 
     if not fix:
         while True:


### PR DESCRIPTION
this crashed in maya 2019, (but expected to crash in all maya version)

openmaya method was incorrectly called causing an exception
i believe it is due a typo, a var which was confused with one of the vars in the same method, which was named very similary